### PR TITLE
Revert "use app context for current message source() instead of a custom solution"

### DIFF
--- a/hyperprocess_macro/src/lib.rs
+++ b/hyperprocess_macro/src/lib.rs
@@ -963,7 +963,6 @@ fn generate_message_handlers(
                             }
                             hyperware_app_common::APP_CONTEXT.with(|ctx| {
                                 ctx.borrow_mut().current_path = None;
-                                ctx.borrow_mut().current_message = None;
                             });
                         },
                         hyperware_process_lib::http::server::HttpServerRequest::WebSocketPush { channel_id, message_type } => {
@@ -992,10 +991,6 @@ fn generate_message_handlers(
                     hyperware_process_lib::logging::warn!("Failed to parse HTTP server request: {}", e);
                 }
             }
-            // Clear current message after handling
-            hyperware_app_common::APP_CONTEXT.with(|ctx| {
-                ctx.borrow_mut().current_message = None;
-            });
         }
 
         /// Handle local messages
@@ -1016,10 +1011,6 @@ fn generate_message_handlers(
                     hyperware_process_lib::logging::warn!("Failed to deserialize local request into HPMRequest enum: {}", e);
                 }
             }
-            // Clear current message after handling
-            hyperware_app_common::APP_CONTEXT.with(|ctx| {
-                ctx.borrow_mut().current_message = None;
-            });
         }
 
         /// Handle remote messages
@@ -1039,10 +1030,6 @@ fn generate_message_handlers(
                     hyperware_process_lib::logging::warn!("Failed to deserialize remote request into HPMRequest enum: {}\nRaw request value: {:?}", e, message.body());
                 }
             }
-            // Clear current message after handling
-            hyperware_app_common::APP_CONTEXT.with(|ctx| {
-                ctx.borrow_mut().current_message = None;
-            });
         }
     }
 }
@@ -1119,6 +1106,21 @@ fn generate_component_impl(
     };
 
     quote! {
+        thread_local! {
+            static CURRENT_MESSAGE: std::cell::RefCell<Option<hyperware_process_lib::Message>> =
+                std::cell::RefCell::new(None);
+        }
+
+        fn source() -> hyperware_process_lib::Address {
+            CURRENT_MESSAGE.with(|cell| {
+                cell.borrow()
+                    .as_ref()
+                    .expect("No message in current context")
+                    .source()
+                    .clone()
+            })
+        }
+
         wit_bindgen::generate!({
             path: "../target/wit",
             world: #wit_world,
@@ -1178,8 +1180,8 @@ fn generate_component_impl(
 
                     match hyperware_process_lib::await_message() {
                         Ok(message) => {
-                            hyperware_app_common::APP_CONTEXT.with(|ctx| {
-                                ctx.borrow_mut().current_message = Some(message.clone());
+                            CURRENT_MESSAGE.with(|cell| {
+                                *cell.borrow_mut() = Some(message.clone());
                             });
                             match message {
                                 hyperware_process_lib::Message::Response { body, context, .. } => {

--- a/hyperware_app_common/src/lib.rs
+++ b/hyperware_app_common/src/lib.rs
@@ -28,7 +28,6 @@ thread_local! {
         executor: Executor::new(),
         current_path: None,
         current_server: None,
-        current_message: None,
     });
 
     pub static RESPONSE_REGISTRY: RefCell<HashMap<String, Vec<u8>>> = RefCell::new(HashMap::new());
@@ -39,7 +38,6 @@ pub struct AppContext {
     pub executor: Executor,
     pub current_path: Option<String>,
     pub current_server: Option<*mut HttpServer>,
-    pub current_message: Option<Message>,
 }
 
 // Access function for the current path
@@ -50,18 +48,6 @@ pub fn get_path() -> Option<String> {
 // Access function for the current server
 pub fn get_server() -> Option<&'static mut HttpServer> {
     APP_CONTEXT.with(|ctx| ctx.borrow().current_server.map(|ptr| unsafe { &mut *ptr }))
-}
-
-// Access function for the source address of the current message
-pub fn source() -> hyperware_process_lib::Address {
-    APP_CONTEXT.with(|ctx| {
-        ctx.borrow()
-            .current_message
-            .as_ref()
-            .expect("No message in current context")
-            .source()
-            .clone()
-    })
 }
 
 pub struct Executor {


### PR DESCRIPTION
Reverts hyperware-ai/hyperprocess-macro#13