### PR TITLE
Fix: local message incoming from rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1628,7 +1628,7 @@ dependencies = [
 [[package]]
 name = "hyperware_process_lib"
 version = "2.2.0"
-source = "git+https://github.com/hyperware-ai/process_lib?rev=a16d47a#a16d47a2bfae7864e97d70a3914829b4e54a4033"
+source = "git+https://github.com/hyperware-ai/process_lib?rev=b9f1ead#b9f1ead63356bfd4b60b337a380fef1be81d81c6"
 dependencies = [
  "alloy",
  "alloy-primitives",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2099,7 +2099,7 @@ fn generate_component_impl(
             // Initialize logging
             hyperware_process_lib::logging::init_logging(
                 hyperware_process_lib::logging::Level::DEBUG,
-                hyperware_process_lib::logging::Level::DEBUG,
+                hyperware_process_lib::logging::Level::INFO,
                 None, Some((0, 0, 1, 1)), None
             ).unwrap();
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1668,7 +1668,6 @@ fn generate_http_handler_dispatcher(
     quote! {
         hyperware_process_lib::logging::debug!("Starting handler matching for {} {}", http_method, current_path);
 
-        
         if blob_opt.is_some() && !blob_opt.as_ref().unwrap().bytes.is_empty() {
             hyperware_process_lib::logging::debug!("Request has body, using two-phase matching");
 
@@ -1961,14 +1960,12 @@ fn generate_message_handlers(
 
             match serde_json::from_slice::<hyperware_process_lib::http::server::HttpServerRequest>(message.body()) {
                 Ok(http_server_request) => {
-                    match http_server_request.clone() {
+                    match http_server_request {
                         hyperware_process_lib::http::server::HttpServerRequest::Http(http_request) => {
-
                             hyperware_process_lib::logging::debug!("Processing HTTP request, message has blob: {}", blob_opt.is_some());
                             if let Some(ref blob) = blob_opt {
                                 hyperware_process_lib::logging::debug!("Blob size: {} bytes, content: {}", blob.bytes.len(), String::from_utf8_lossy(&blob.bytes[..std::cmp::min(200, blob.bytes.len())]));
                             }
-                            hyperware_process_lib::logging::debug!("http_server_request: {:?}", http_server_request.clone());
                             #http_context_setup
                             #http_request_parsing
                             #http_dispatcher
@@ -2202,8 +2199,6 @@ fn generate_component_impl(
                                         if let Ok(http_server_request) = serde_json::from_slice::<hyperware_process_lib::http::server::HttpServerRequest>(message.body()) {
                                             handle_http_server_message(&mut state, message);
                                         } else {
-                                            // the only thing is that erroring will be clunky, because if there is a misformatted http message, we will parse it as a local message
-                                            // can add logging in the local message handler to say if there was a misformatted http msg it would have ended up there
                                             handle_local_message(&mut state, message);
                                         }
                                     } else if message.is_local() && message.source().process == "http-client:distro:sys" {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2205,6 +2205,8 @@ fn generate_component_impl(
                                         handle_websocket_client_message(&mut state, message);
                                     } else if message.is_local() && message.source().process == "eth:distro:sys" {
                                         handle_eth_message(&mut state, message);
+                                    } else if message.is_local() {
+                                        handle_local_message(&mut state, message);
                                     } else {
                                         handle_remote_message(&mut state, message);
                                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1960,13 +1960,14 @@ fn generate_message_handlers(
 
             match serde_json::from_slice::<hyperware_process_lib::http::server::HttpServerRequest>(message.body()) {
                 Ok(http_server_request) => {
-                    match http_server_request {
+                    match http_server_request.clone() {
                         hyperware_process_lib::http::server::HttpServerRequest::Http(http_request) => {
+
                             hyperware_process_lib::logging::debug!("Processing HTTP request, message has blob: {}", blob_opt.is_some());
                             if let Some(ref blob) = blob_opt {
                                 hyperware_process_lib::logging::debug!("Blob size: {} bytes, content: {}", blob.bytes.len(), String::from_utf8_lossy(&blob.bytes[..std::cmp::min(200, blob.bytes.len())]));
                             }
-
+                            hyperware_process_lib::logging::debug!("http_server_request: {:?}", http_server_request.clone());
                             #http_context_setup
                             #http_request_parsing
                             #http_dispatcher
@@ -2100,7 +2101,7 @@ fn generate_component_impl(
             // Initialize logging
             hyperware_process_lib::logging::init_logging(
                 hyperware_process_lib::logging::Level::DEBUG,
-                hyperware_process_lib::logging::Level::INFO,
+                hyperware_process_lib::logging::Level::DEBUG,
                 None, Some((0, 0, 1, 1)), None
             ).unwrap();
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1668,6 +1668,7 @@ fn generate_http_handler_dispatcher(
     quote! {
         hyperware_process_lib::logging::debug!("Starting handler matching for {} {}", http_method, current_path);
 
+        
         if blob_opt.is_some() && !blob_opt.as_ref().unwrap().bytes.is_empty() {
             hyperware_process_lib::logging::debug!("Request has body, using two-phase matching");
 
@@ -2197,7 +2198,6 @@ fn generate_component_impl(
                                     });
                                 }
                                 hyperware_process_lib::Message::Request { .. } => {
-                                    hyperware_process_lib::logging::debug!("received message: {:?}", message);
                                     if message.is_local() && message.source().process == "http-server:distro:sys" {
                                         if let Ok(http_server_request) = serde_json::from_slice::<hyperware_process_lib::http::server::HttpServerRequest>(message.body()) {
                                             handle_http_server_message(&mut state, message);


### PR DESCRIPTION
- `handle_http_server_message` function has not been tampered with, so there is some redundancy. I.e. the message is being transformed twice, outside and inside the handler. I prefer that the functions `handle_xyz_message` have the same format. If priority is different, I can trim it down and change the name to e.g. `handle_http_server_http_request`.

- There are four cases of messages relevant in this context: local through some app, local through http-server, remote through some app, remote through http-server.
- When done with `kit inject-message`, messages will go through `http-server:distro:sys`. So whether I send a message tagged as remote or as local, they will both end up in the local handler. Not sure if this is correct behavior, but it makes sense given that all calls via the rpc endpoint are expected to be local (afaict), otherwise they would be hitting http endpoints directly.

- If there is a misformatted HTTP message, we will parse it as a local message, which might be clunky for devs. I can add logging in the local message handler to say something like "If you are sending an HTTP message (rather than local), it might be formatted wrong."